### PR TITLE
ci: enable scheduled trivy scanner and report vulnerabilities as GH issues

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -16,6 +16,5 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
-      report-vulnerabilities: true
       severity: "HIGH,CRITICAL"
       branch: ${{ matrix.branch }}

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -1,0 +1,21 @@
+name: Scan images
+
+on:  
+  schedule:
+    - cron: '00 23 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  scan-images:
+    name: Scan published images and report vulnerabilities
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
+    strategy:
+      matrix:
+        branch: [main, track/2.1]
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    with:
+      report-vulnerabilities: true
+      severity: "HIGH,CRITICAL"
+      branch: ${{ matrix.branch }}


### PR DESCRIPTION
This workflow enables a scheduled scanner (that can also be run from a workflow dispatch) to scan images using the trivy scanner. At the same time, enables the automatic creation/edition of Github issues when a vulnerability is found.

Fixes #18