### PR TITLE
docs: add SECURITY.md to the repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,5 +6,5 @@ The Charmed MLflow project releases with a cadence of ~6 months, supports two mi
 
 ## Reporting a Vulnerability
 
-To report a security issue, file a [Private Security Report](https://github.com/canonical/mlflow-operator/security/advisories/new) with a description of the issue, the steps you took that led you to the issue, affected versions, and, if known, mitigations for the issue.
+To report a security issue, file a [Private Security Report](https://github.com/canonical/base-mlflow/security/advisories/new) with a description of the issue, the steps you took that led you to the issue, affected versions, and, if known, mitigations for the issue.
 The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security policy
+
+## Supported Versions
+
+The Charmed MLflow project releases with a cadence of ~6 months, supports two minor versions of MLflow, and keeps up to date with the latest upstream version. Whenever a new version of Charmed MLflow is released, the oldest version is dropped from support.
+
+## Reporting a Vulnerability
+
+To report a security issue, file a [Private Security Report](https://github.com/canonical/mlflow-operator/security/advisories/new) with a description of the issue, the steps you took that led you to the issue, affected versions, and, if known, mitigations for the issue.
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
This commit adds the SECURITY.md file to expose the security policy of the CMLflow project, as well as inform users how they can report security/vulnerability issues.

Fixes #20