### PR TITLE
feat: Add rock-ci-metadata.yaml

### DIFF
--- a/mlflow/rock-ci-metadata.yaml
+++ b/mlflow/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/mlflow-operator.git
+
+    replace-image:
+      - file: metadata.yaml
+        path: resources.oci-image.upstream-source


### PR DESCRIPTION
Introduce a `rock-ci-metadata.yaml` for rock integration. For full file
creation steps, refer to
https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114.

Closes #28