### PR TITLE
fix: create config folders and `chown` them to `daemon` user for `mlflow`

### DIFF
--- a/mlflow/rockcraft.yaml
+++ b/mlflow/rockcraft.yaml
@@ -36,3 +36,15 @@ parts:
     - tzdata
     python-requirements:
     - requirements.txt
+
+  non-root-user:
+    plugin: nil
+    after:
+      - mlflow
+    override-build: |
+      # make config dir
+      mkdir -p $CRAFT_PART_INSTALL/metrics
+    override-prime: |
+      craftctl default
+      install -d -o 584792 -g 584792 -m 770 \
+        metrics


### PR DESCRIPTION
This PR modifies the `rockcraft.yaml` of rocks used by `mlflow` charm requiring to write config files to the filesystem.
With this PR, configuration folders are already created and owned by user `_daemon_`, so that the unprivileged `pebble` service running in the charm can read/write there.